### PR TITLE
Fix _compat.is_uploadfile_sequence_annotation

### DIFF
--- a/fastapi/_compat.py
+++ b/fastapi/_compat.py
@@ -623,7 +623,8 @@ def is_uploadfile_sequence_annotation(annotation: Any) -> bool:
                 at_least_one = True
                 continue
         return at_least_one
-    return field_annotation_is_sequence(annotation) and all(
+    args = get_args(annotation)
+    return field_annotation_is_sequence(annotation) and args and all(
         is_uploadfile_or_nonable_uploadfile_annotation(sub_annotation)
-        for sub_annotation in get_args(annotation)
+        for sub_annotation in args
     )


### PR DESCRIPTION
We are using `BaseCollectionModel` class from `pydantic-collection` package as route parameters.
After updating to the latest FastAPI version it is not automatically recognized as body parameters.
We have determined that the reason is the incorrect implementation of the `_compat.is_uploadfile_sequence_annotation` function.